### PR TITLE
Remove the unneeded third-party repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,6 @@ task wrapper(type: Wrapper) {
 }
 
 repositories {
-    maven { url "http://dl.bintray.com/populov/maven" }
     mavenCentral()
 }
 


### PR DESCRIPTION
This repository is [not required](https://travis-ci.org/gerc99/SawimNE/builds/66702515) for Sawim build to succeed.
It also [blocks](https://f-droid.org/forums/topic/sawim) Sawim from being accepted in F-Droid.