### PR TITLE
Hide app icon from toolbar

### DIFF
--- a/src/ru/sawim/activities/BaseActivity.java
+++ b/src/ru/sawim/activities/BaseActivity.java
@@ -7,7 +7,6 @@ import android.support.v7.app.ActionBar;
 import android.support.v7.app.ActionBarActivity;
 import ru.sawim.ExternalApi;
 import ru.sawim.R;
-import ru.sawim.SawimResources;
 import ru.sawim.Scheme;
 
 /**
@@ -23,11 +22,10 @@ public class BaseActivity extends ActionBarActivity {
         ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(false);
         actionBar.setDisplayShowTitleEnabled(true);
-        actionBar.setDisplayUseLogoEnabled(true);
+        actionBar.setDisplayUseLogoEnabled(false);
         actionBar.setDisplayShowHomeEnabled(true);
         actionBar.setDisplayShowCustomEnabled(false);
         actionBar.setNavigationMode(ActionBar.NAVIGATION_MODE_STANDARD);
-        actionBar.setIcon(SawimResources.APP_ICON);
         actionBar.setTitle(title);
     }
 


### PR DESCRIPTION
Application icon in toolbar doesn't fit to Android Material design.