### PR TITLE
Fixing squid:S1197- Array designators "[]" should be on the type, not the variable

### DIFF
--- a/src/protocol/xmpp/Vcard.java
+++ b/src/protocol/xmpp/Vcard.java
@@ -77,7 +77,7 @@ public class Vcard {
                 connection.singleUserInfo = null;
                 return;
             }
-            String name[] = new String[3];
+            String[] name = new String[3];
             name[0] = vCard.getFirstNodeValue("N", "GIVEN");
             name[1] = vCard.getFirstNodeValue("N", "MIDDLE");
             name[2] = vCard.getFirstNodeValue("N", "FAMILY");

--- a/src/protocol/xmpp/Xmpp.java
+++ b/src/protocol/xmpp/Xmpp.java
@@ -746,7 +746,7 @@ public final class Xmpp extends Protocol implements FormListener {
     private static final int REASON_INVITE = 9;
 
     public String onlineConference(ConcurrentHashMap<String, Contact> contacts) {
-        String list[] = new String[contacts.size()];
+        String[] list = new String[contacts.size()];
         String items = "";
         for (int i = 1; i < contacts.values().size(); ++i) {
             XmppContact c = (XmppContact) contacts.values().iterator().next();

--- a/src/ru/sawim/comm/StringConvertor.java
+++ b/src/ru/sawim/comm/StringConvertor.java
@@ -110,7 +110,7 @@ public final class StringConvertor {
                 systemWin1251 = false;
             }
         }
-        byte buf[] = new byte[s.length()];
+        byte[] buf = new byte[s.length()];
         int size = s.length();
         for (int i = 0; i < size; ++i) {
             char ch = s.charAt(i);
@@ -157,7 +157,7 @@ public final class StringConvertor {
         return buf;
     }
 
-    public static String byteArray1251ToString(byte buf[], int pos, int len) {
+    public static String byteArray1251ToString(byte[] buf, int pos, int len) {
         if (systemWin1251) {
             try {
                 return new String(buf, pos, len, "Windows-1251");

--- a/src/ru/sawim/icons/Avatars.java
+++ b/src/ru/sawim/icons/Avatars.java
@@ -128,7 +128,7 @@ public class Avatars {
     }
 
     public static int getColorForName(String character) {
-        int colors[] = SawimApplication.getContext().getResources().getIntArray(R.array.avatar_colors);
+        int[] colors = SawimApplication.getContext().getResources().getIntArray(R.array.avatar_colors);
         if (character.isEmpty()) {
             return colors[colors.length - 1];
         }

--- a/src/ru/sawim/icons/ImageCache.java
+++ b/src/ru/sawim/icons/ImageCache.java
@@ -64,7 +64,7 @@ public class ImageCache {
                                     } catch (FileNotFoundException e) {
                                         e.printStackTrace();
                                     }
-                                    byte fileContent[] = new byte[(int) file.length()];
+                                    byte[] fileContent = new byte[(int) file.length()];
                                     try {
                                         if (inputStream != null) {
                                             inputStream.read(fileContent);

--- a/src/ru/sawim/io/BlobStorage.java
+++ b/src/ru/sawim/io/BlobStorage.java
@@ -62,7 +62,7 @@ public final class BlobStorage {
         //SawimApplication.getDatabaseHelper().close();
     }
 
-    public void addRecord(final byte data[]) {
+    public void addRecord(final byte[] data) {
         thread.execute(new SqlAsyncTask.OnTaskListener() {
 
             @Override
@@ -85,7 +85,7 @@ public final class BlobStorage {
         return bytes;
     }
 
-    public void setRecord(final int id, final byte data[]) {
+    public void setRecord(final int id, final byte[] data) {
         thread.execute(new SqlAsyncTask.OnTaskListener() {
             @Override
             public void run() {

--- a/src/ru/sawim/io/StorageConvertor.java
+++ b/src/ru/sawim/io/StorageConvertor.java
@@ -130,7 +130,7 @@ public final class StorageConvertor {
     private static byte[] readFile(String recordFileName) {
         Context context = SawimApplication.getContext();
         DataInputStream dis = null;
-        byte data[] = new byte[0];
+        byte[] data = new byte[0];
         try {
             dis = new DataInputStream(context.openFileInput(recordFileName));
             dis.readInt(); // Record ID

--- a/src/ru/sawim/modules/crypto/MessageDigest.java
+++ b/src/ru/sawim/modules/crypto/MessageDigest.java
@@ -8,11 +8,11 @@ public class MessageDigest {
     private java.security.MessageDigest digest;
 
     static byte[] calculate(MessageDigest digest, String input) {
-        byte data[] = StringConvertor.stringToByteArrayUtf8(input);
+        byte[] data = StringConvertor.stringToByteArrayUtf8(input);
         return calculate(digest, data);
     }
 
-    static byte[] calculate(MessageDigest digest, byte input[]) {
+    static byte[] calculate(MessageDigest digest, byte[] input) {
         digest.update(input);
         return digest.getDigestBits();
     }
@@ -34,7 +34,7 @@ public class MessageDigest {
         digest.update(input);
     }
 
-    public void update(byte input[]) {
+    public void update(byte[] input) {
         digest.update(input);
     }
 
@@ -47,7 +47,7 @@ public class MessageDigest {
     }
 
     public String getDigestHex() {
-        byte digestBits[] = digest.digest();
+        byte[] digestBits = digest.digest();
         StringBuilder out = new StringBuilder();
         for (byte digestBit : digestBits) {
             char c = (char) ((digestBit >> 4) & 0xf);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule "squid:S1197- Array designators "[]" should be on the type, not the variable". You can find more information about the issues here:
https://dev.eclipse.org/sonar/rules/show/squid:S1197


Please let me know if you have any questions.
Sameer Misger