### PR TITLE
Ignore untracked files in `mtm` submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "deps/mtm"]
 	path = deps/mtm
 	url = https://github.com/ge0rg/MemorizingTrustManager.git
+	ignore = untracked


### PR DESCRIPTION
`deps/mtm` directory contains untracked IntelliJ IDEA project files, and Git marks this directory as changed. Because Sawim .gitignore rules don't apply to submodules, we just tell Git ignore these files by configuring `mtm` submodule.